### PR TITLE
Fixed issue with MDIX assembly still being copied to output directory.

### DIFF
--- a/single_file_exe/Program.cs
+++ b/single_file_exe/Program.cs
@@ -12,11 +12,17 @@ namespace single_file_exe
         [System.STAThreadAttribute()]
         public static void Main()
         {
+            var loadedAssemblies = new Dictionary<string, Assembly>();
             AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
             {
                 String resourceName = "single_file_exe.Res." +
-
                 new AssemblyName(args.Name).Name + ".dll";
+
+                //Must return the EXACT same assembly, do not reload from a new stream
+                if (loadedAssemblies.TryGetValue(resourceName, out Assembly loadedAssembly))
+                {
+                    return loadedAssembly;
+                }
 
                 using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
                 {
@@ -26,7 +32,9 @@ namespace single_file_exe
 
                     stream.Read(assemblyData, 0, assemblyData.Length);
 
-                    return Assembly.Load(assemblyData);
+                    var assembly =  Assembly.Load(assemblyData);
+                    loadedAssemblies[resourceName] = assembly;
+                    return assembly;
                 }
             };
             App app = new App();

--- a/single_file_exe/single_file_exe.csproj
+++ b/single_file_exe/single_file_exe.csproj
@@ -58,6 +58,7 @@
     </Reference>
     <Reference Include="MaterialDesignThemes.Wpf, Version=2.5.0.1205, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MaterialDesignThemes.2.5.0.1205\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
Fixed issue with multiple instances of the same assembly being returned. The CLR will treat these as different assemblies and we don't want that.